### PR TITLE
Update Maven repository name in distribution management

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
     <distributionManagement>
         <repository>
             <id>github</id>
-            <name>GitHub OWNER Apache Maven Packages</name>
+            <name>GitHub bycrafter Apache Maven Packages</name>
             <url>https://maven.pkg.github.com/bycrafter/bom</url>
         </repository>
     </distributionManagement>


### PR DESCRIPTION
Renamed the repository name in the pom.xml to reflect the proper owner, changing it from "OWNER" to "bycrafter." This ensures clarity and consistency with the repository's actual configuration.